### PR TITLE
Refactor summary filter

### DIFF
--- a/domain/src/main/kotlin/moneytree/domain/entity/Expense.kt
+++ b/domain/src/main/kotlin/moneytree/domain/entity/Expense.kt
@@ -30,8 +30,8 @@ data class ExpenseSummary(
 )
 
 data class ExpenseSummaryFilter(
-    val startDate: LocalDate?,
-    val endDate: LocalDate?,
-    val vendorIds: List<UUID>?,
-    val expenseCategoryIds: List<UUID>?
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+    val vendorIds: List<UUID>,
+    val expenseCategoryIds: List<UUID>
 ) : Filter()

--- a/domain/src/main/kotlin/moneytree/domain/entity/Filter.kt
+++ b/domain/src/main/kotlin/moneytree/domain/entity/Filter.kt
@@ -1,3 +1,6 @@
 package moneytree.domain.entity
 
 open class Filter
+
+const val DEFAULT_MINUS_MONTHS = 3L
+const val DEFAULT_LIMIT_ENTITY = 100

--- a/domain/src/main/kotlin/moneytree/domain/entity/Income.kt
+++ b/domain/src/main/kotlin/moneytree/domain/entity/Income.kt
@@ -30,7 +30,7 @@ data class IncomeSummary(
 )
 
 data class IncomeSummaryFilter(
-    val startDate: LocalDate?,
-    val endDate: LocalDate?,
-    val incomeCategoryIds: List<UUID>?
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+    val incomeCategoryIds: List<UUID>
 ) : Filter()

--- a/mt-api/src/main/kotlin/moneytree/api/ExpenseApi.kt
+++ b/mt-api/src/main/kotlin/moneytree/api/ExpenseApi.kt
@@ -1,5 +1,6 @@
 package moneytree.api
 
+import java.time.LocalDate
 import moneytree.MtApiRoutesWithSummary
 import moneytree.domain.Repository
 import moneytree.domain.SummaryRepository
@@ -55,10 +56,10 @@ class ExpenseApi(
 
     override fun getSummary(request: Request): Response {
         val expenseSummaryFilter = ExpenseSummaryFilter(
-            startDate = queryStartDate(request),
-            endDate = queryEndDate(request),
-            vendorIds = queryVendors(request)?.split(',')?.toUUIDList(),
-            expenseCategoryIds = queryExpenseCategories(request)?.split(',')?.toUUIDList()
+            startDate = queryStartDate(request) ?: LocalDate.now().minusMonths(3),
+            endDate = queryEndDate(request) ?: LocalDate.now(),
+            vendorIds = queryVendors(request)?.split(',')?.toUUIDList() ?: emptyList(),
+            expenseCategoryIds = queryExpenseCategories(request)?.split(',')?.toUUIDList() ?: emptyList()
         )
 
         return processGetResult(summaryRepository.getSummary(expenseSummaryFilter), summaryListLens)

--- a/mt-api/src/main/kotlin/moneytree/api/ExpenseApi.kt
+++ b/mt-api/src/main/kotlin/moneytree/api/ExpenseApi.kt
@@ -4,6 +4,7 @@ import java.time.LocalDate
 import moneytree.MtApiRoutesWithSummary
 import moneytree.domain.Repository
 import moneytree.domain.SummaryRepository
+import moneytree.domain.entity.DEFAULT_MINUS_MONTHS
 import moneytree.domain.entity.Expense
 import moneytree.domain.entity.ExpenseSummary
 import moneytree.domain.entity.ExpenseSummaryFilter
@@ -56,7 +57,7 @@ class ExpenseApi(
 
     override fun getSummary(request: Request): Response {
         val expenseSummaryFilter = ExpenseSummaryFilter(
-            startDate = queryStartDate(request) ?: LocalDate.now().minusMonths(3),
+            startDate = queryStartDate(request) ?: LocalDate.now().minusMonths(DEFAULT_MINUS_MONTHS),
             endDate = queryEndDate(request) ?: LocalDate.now(),
             vendorIds = queryVendors(request)?.split(',')?.toUUIDList() ?: emptyList(),
             expenseCategoryIds = queryExpenseCategories(request)?.split(',')?.toUUIDList() ?: emptyList()

--- a/mt-api/src/main/kotlin/moneytree/api/IncomeApi.kt
+++ b/mt-api/src/main/kotlin/moneytree/api/IncomeApi.kt
@@ -4,6 +4,7 @@ import java.time.LocalDate
 import moneytree.MtApiRoutesWithSummary
 import moneytree.domain.Repository
 import moneytree.domain.SummaryRepository
+import moneytree.domain.entity.DEFAULT_MINUS_MONTHS
 import moneytree.domain.entity.Income
 import moneytree.domain.entity.IncomeSummary
 import moneytree.domain.entity.IncomeSummaryFilter
@@ -55,7 +56,7 @@ class IncomeApi(
 
     override fun getSummary(request: Request): Response {
         val incomeSummaryFilter = IncomeSummaryFilter(
-            startDate = queryStartDate(request) ?: LocalDate.now().minusMonths(3),
+            startDate = queryStartDate(request) ?: LocalDate.now().minusMonths(DEFAULT_MINUS_MONTHS),
             endDate = queryEndDate(request) ?: LocalDate.now(),
             incomeCategoryIds = queryIncomeCategories(request)?.split(',')?.toUUIDList() ?: emptyList()
         )

--- a/mt-api/src/main/kotlin/moneytree/api/IncomeApi.kt
+++ b/mt-api/src/main/kotlin/moneytree/api/IncomeApi.kt
@@ -1,5 +1,6 @@
 package moneytree.api
 
+import java.time.LocalDate
 import moneytree.MtApiRoutesWithSummary
 import moneytree.domain.Repository
 import moneytree.domain.SummaryRepository
@@ -54,9 +55,9 @@ class IncomeApi(
 
     override fun getSummary(request: Request): Response {
         val incomeSummaryFilter = IncomeSummaryFilter(
-            startDate = queryStartDate(request),
-            endDate = queryEndDate(request),
-            incomeCategoryIds = queryIncomeCategories(request)?.split(',')?.toUUIDList()
+            startDate = queryStartDate(request) ?: LocalDate.now().minusMonths(3),
+            endDate = queryEndDate(request) ?: LocalDate.now(),
+            incomeCategoryIds = queryIncomeCategories(request)?.split(',')?.toUUIDList() ?: emptyList()
         )
 
         return processGetResult(summaryRepository.getSummary(incomeSummaryFilter), summaryListLens)

--- a/persist/src/main/kotlin/moneytree/persist/repository/ExpenseRepository.kt
+++ b/persist/src/main/kotlin/moneytree/persist/repository/ExpenseRepository.kt
@@ -1,7 +1,6 @@
 package moneytree.persist.repository
 
 import moneytree.domain.entity.Expense as ExpenseDomain
-import java.time.LocalDate
 import java.util.UUID
 import moneytree.domain.Repository
 import moneytree.domain.SummaryRepository
@@ -187,25 +186,21 @@ class ExpenseRepository(
         }
     }
 
-    private fun ExpenseSummaryFilter?.toWhereClause(): Condition {
+    private fun ExpenseSummaryFilter.toWhereClause(): Condition {
         var condition = DSL.noCondition()
-
-        if (this == null) return condition
 
         condition = condition.and(
             EXPENSE.TRANSACTION_DATE.between(
-                this.startDate ?: LocalDate.parse("1000-01-01"),
-                this.endDate ?: LocalDate.now()
+                this.startDate,
+                this.endDate
             )
         )
 
-        this.expenseCategoryIds?.let {
-            condition = condition.and(EXPENSE.EXPENSE_CATEGORY.`in`(it))
-        }
+        if (this.expenseCategoryIds.isNotEmpty())
+            condition = condition.and(EXPENSE.EXPENSE_CATEGORY.`in`(this.expenseCategoryIds))
 
-        this.vendorIds?.let {
-            condition = condition.and(EXPENSE.VENDOR.`in`(it))
-        }
+        if (this.vendorIds.isNotEmpty())
+            condition = condition.and(EXPENSE.VENDOR.`in`(this.vendorIds))
 
         return condition
     }

--- a/persist/src/main/kotlin/moneytree/persist/repository/IncomeRepository.kt
+++ b/persist/src/main/kotlin/moneytree/persist/repository/IncomeRepository.kt
@@ -1,7 +1,6 @@
 package moneytree.persist.repository
 
 import moneytree.domain.entity.Income as IncomeDomain
-import java.time.LocalDate
 import java.util.UUID
 import moneytree.domain.Repository
 import moneytree.domain.SummaryRepository
@@ -185,21 +184,18 @@ class IncomeRepository(
         }
     }
 
-    private fun IncomeSummaryFilter?.toWhereClause(): Condition {
+    private fun IncomeSummaryFilter.toWhereClause(): Condition {
         var condition = DSL.noCondition()
-
-        if (this == null) return condition
 
         condition = condition.and(
             INCOME.TRANSACTION_DATE.between(
-                this.startDate ?: LocalDate.parse("1000-01-01"),
-                this.endDate ?: LocalDate.now()
+                this.startDate,
+                this.endDate
             )
         )
 
-        this.incomeCategoryIds?.let {
-            condition = condition.and(INCOME.INCOME_CATEGORY.`in`(it))
-        }
+        if (this.incomeCategoryIds.isNotEmpty())
+            condition = condition.and(INCOME.INCOME_CATEGORY.`in`(this.incomeCategoryIds))
 
         return condition
     }

--- a/persist/src/test/kotlin/moneytree/persist/repository/ExpenseRepositoryTest.kt
+++ b/persist/src/test/kotlin/moneytree/persist/repository/ExpenseRepositoryTest.kt
@@ -328,59 +328,6 @@ class ExpenseRepositoryTest {
     }
 
     @Test
-    fun `getSummary happy path with null filter`() {
-        val randomVendor = insertRandomVendor()
-        val randomExpenseCategory = insertRandomExpenseCategory()
-
-        val randomUUID = UUID.randomUUID()
-        val todayLocalDate = LocalDate.now()
-        val randomTransactionAmount = randomBigDecimal()
-        val vendorId = randomVendor.id ?: fail("Vendor id cannot be null!")
-        val expenseCategoryId = randomExpenseCategory.id ?: fail("Expense category id cannot be null!")
-        val notes = randomString()
-        val hide = false
-
-        val expense = Expense(
-            id = randomUUID,
-            transactionDate = todayLocalDate,
-            transactionAmount = randomTransactionAmount,
-            vendor = vendorId,
-            expenseCategory = expenseCategoryId,
-            notes = notes,
-            hide = hide
-        )
-
-        val expenseSummary = ExpenseSummary(
-            id = randomUUID,
-            transactionDate = todayLocalDate,
-            transactionAmount = randomTransactionAmount,
-            vendorId = vendorId,
-            vendorName = randomVendor.name,
-            expenseCategoryId = expenseCategoryId,
-            expenseCategoryName = randomExpenseCategory.name,
-            notes = notes,
-            hide = hide
-        )
-
-        val expenseSummaryFilter = ExpenseSummaryFilter(
-            startDate = null,
-            endDate = null,
-            vendorIds = null,
-            expenseCategoryIds = null
-        )
-
-        val insertResult = expenseRepository.insert(expense)
-        insertResult.shouldBeOk()
-
-        val summaryResult = expenseRepository.getSummary(expenseSummaryFilter)
-        summaryResult.shouldBeOk()
-        summaryResult.onOk {
-            it.size shouldBeGreaterThanOrEqual 1
-            it shouldContain expenseSummary
-        }
-    }
-
-    @Test
     fun `getSummary happy path with valid filter`() {
         val randomVendor = insertRandomVendor()
         val randomExpenseCategory = insertRandomExpenseCategory()
@@ -459,8 +406,8 @@ class ExpenseRepositoryTest {
         val expenseSummaryFilter = ExpenseSummaryFilter(
             startDate = todayLocalDate.plusDays(1),
             endDate = todayLocalDate.plusDays(2),
-            vendorIds = null,
-            expenseCategoryIds = null
+            vendorIds = emptyList(),
+            expenseCategoryIds = emptyList()
         )
 
         val insertResult = expenseRepository.insert(expense)
@@ -497,10 +444,10 @@ class ExpenseRepositoryTest {
         )
 
         val expenseSummaryFilter = ExpenseSummaryFilter(
-            startDate = null,
-            endDate = null,
+            startDate = todayLocalDate.minusDays(1),
+            endDate = todayLocalDate,
             vendorIds = listOf(UUID.randomUUID()),
-            expenseCategoryIds = null
+            expenseCategoryIds = emptyList()
         )
 
         val insertResult = expenseRepository.insert(expense)
@@ -537,9 +484,9 @@ class ExpenseRepositoryTest {
         )
 
         val expenseSummaryFilter = ExpenseSummaryFilter(
-            startDate = null,
-            endDate = null,
-            vendorIds = null,
+            startDate = todayLocalDate.minusDays(1),
+            endDate = todayLocalDate,
+            vendorIds = emptyList(),
             expenseCategoryIds = listOf(UUID.randomUUID())
         )
 

--- a/persist/src/test/kotlin/moneytree/persist/repository/IncomeRepositoryTest.kt
+++ b/persist/src/test/kotlin/moneytree/persist/repository/IncomeRepositoryTest.kt
@@ -295,56 +295,6 @@ class IncomeRepositoryTest {
     }
 
     @Test
-    fun `getSummary happy path with null filter`() {
-        val randomIncomeCategory = insertRandomIncomeCategory()
-
-        val randomUUID = UUID.randomUUID()
-        val randomSource = randomString()
-        val randomIncomeCategoryId = randomIncomeCategory.id ?: fail("Expense category id cannot be null!")
-        val todayLocalDate = LocalDate.now()
-        val randomTransactionAmount = randomBigDecimal()
-        val notes = randomString()
-        val hide = false
-
-        val income = Income(
-            id = randomUUID,
-            source = randomSource,
-            incomeCategory = randomIncomeCategoryId,
-            transactionDate = todayLocalDate,
-            transactionAmount = randomTransactionAmount,
-            notes = notes,
-            hide = hide
-        )
-
-        val incomeSummary = IncomeSummary(
-            id = randomUUID,
-            source = randomSource,
-            incomeCategoryId = randomIncomeCategoryId,
-            incomeCategoryName = randomIncomeCategory.name,
-            transactionDate = todayLocalDate,
-            transactionAmount = randomTransactionAmount,
-            notes = notes,
-            hide = hide
-        )
-
-        val insertResult = incomeRepository.insert(income)
-        insertResult.shouldBeOk()
-
-        val incomeSummaryFilter = IncomeSummaryFilter(
-            startDate = null,
-            endDate = null,
-            incomeCategoryIds = null
-        )
-
-        val summaryResult = incomeRepository.getSummary(incomeSummaryFilter)
-        summaryResult.shouldBeOk()
-        summaryResult.onOk {
-            it.size shouldBeGreaterThanOrEqual 1
-            it shouldContain incomeSummary
-        }
-    }
-
-    @Test
     fun `getSummary returns empty list when filter doesn't meet date range`() {
         val randomIncomeCategory = insertRandomIncomeCategory()
 
@@ -372,7 +322,7 @@ class IncomeRepositoryTest {
         val incomeSummaryFilter = IncomeSummaryFilter(
             startDate = todayLocalDate.plusDays(1),
             endDate = todayLocalDate.plusDays(2),
-            incomeCategoryIds = null
+            incomeCategoryIds = emptyList()
         )
 
         val summaryResult = incomeRepository.getSummary(incomeSummaryFilter)
@@ -408,8 +358,8 @@ class IncomeRepositoryTest {
         insertResult.shouldBeOk()
 
         val incomeSummaryFilter = IncomeSummaryFilter(
-            startDate = null,
-            endDate = null,
+            startDate = todayLocalDate.minusDays(1),
+            endDate = todayLocalDate,
             incomeCategoryIds = listOf(UUID.randomUUID())
         )
 


### PR DESCRIPTION
Made the properties non-nullable  and set the defaults in the mt-api module (although the defaults are defined in domain).

Moved setting the defaults out of persist because it doesn't make sense to have it there. Persist module should only be in charge with communicating with the database only.